### PR TITLE
Changed lifecycle event to beforeDestroy

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,14 +77,14 @@ module.exports = {
                     window.addEventListener('online',  onlineHandler)
                     window.addEventListener('offline',  offlineHandler)
 
-                    this.$once('hook:desktroyed', () => {
+                    this.$once('hook:beforeDestroy', () => {
                         window.removeEventListener('online', onlineHandler)
                         window.removeEventListener('offline', offlineHandler)
                     })
                 }
             }
         }
-        
+
         Vue.directive('online', onlineOnlyDirective)
         Vue.directive('offline', offlineOnlyDirective)
         Vue.mixin(offlineHooksMixin)

--- a/mixin/index.js
+++ b/mixin/index.js
@@ -28,7 +28,7 @@ export default {
           window.addEventListener('online',  onlineHandler)
           window.addEventListener('offline',  offlineHandler)
 
-          this.$once('hook:desktroyed', () => {
+          this.$once('hook:beforeDestroy', () => {
               window.removeEventListener('online', onlineHandler)
               window.removeEventListener('offline', offlineHandler)
           })


### PR DESCRIPTION
Changed lifecycle from `deskrtoyed` (invalid name and events would have never been done because in destroyed the nodes don't exist anymore) to `beforeDestroy` where nodes still exists and event listeners can be removed.